### PR TITLE
Graph updates

### DIFF
--- a/src/frontend/components/dashboard/Home.jsx
+++ b/src/frontend/components/dashboard/Home.jsx
@@ -439,7 +439,7 @@ export default function Home(props) {
                   <ToggleButton value="hourly" aria-label="By hour">
                     By hour
                   </ToggleButton>
-                  <ToggleButton value="daily" aria-label="By day">
+                  <ToggleButton value="daily" aria-label="By day" disabled>
                     By day
                   </ToggleButton>
                 </ToggleButtonGroup>

--- a/src/frontend/components/utils/MainGraph.jsx
+++ b/src/frontend/components/utils/MainGraph.jsx
@@ -81,6 +81,23 @@ export default function MainGraph(props) {
   const [color, setColor] = React.useState('red');
   const { lid, runs, connections, testTypes, metric, group, dateRange } = props;
 
+  function formatHover(runs) {
+    return runs.map(run => {
+      return `<span>${moment(
+        run.TestStartTime,
+        'YYYY-MM-DDThh:mm:ss',
+      )}</span><br><span>${run.TestName} test</span><br><span>${
+        run.MurakamiConnectionType
+      } connection</span><br><span>${run.DownloadValue.toFixed(2)} ${
+        run.DownloadUnit
+      } download</span><br><span>${run.UploadValue.toFixed(2)} ${
+        run.UploadUnit
+      } upload</span><br><span>${run.MinRTTValue.toFixed(2)} ${
+        run.MinRTTUnit
+      } latency</span><br>`;
+    });
+  }
+
   React.useEffect(() => {
     if (runs) {
       const filteredRuns = runs.filter(run => {
@@ -157,6 +174,9 @@ export default function MainGraph(props) {
             type: 'scatter',
             mode: 'markers',
             marker: { color: color },
+            text: formatHover(runs),
+            hoverinfo: 'text',
+            hoverlabel: { bgcolor: '#41454c' },
           },
         ]}
         layout={{

--- a/src/frontend/components/utils/MainGraph.jsx
+++ b/src/frontend/components/utils/MainGraph.jsx
@@ -78,6 +78,7 @@ export default function MainGraph(props) {
   const [testSummary, setTestSummary] = React.useState(null);
   const [titleText, setTitleText] = React.useState(null);
   const [isLoaded, setIsLoaded] = React.useState(false);
+  const [color, setColor] = React.useState('red');
   const { lid, runs, connections, testTypes, metric, group, dateRange } = props;
 
   React.useEffect(() => {
@@ -96,6 +97,15 @@ export default function MainGraph(props) {
         if (testTypes.length) {
           if (!testTypes.includes(run.TestName)) {
             return false;
+          }
+          if (
+            run.TestName.toLowerCase() == 'ndt' ||
+            run.TestName.toLowerCase() == 'ndt5' ||
+            run.TestName.toLowerCase() == 'ndt7'
+          ) {
+            setColor('red');
+          } else {
+            setColor('orange');
           }
         }
         return connections.length && testTypes.length;
@@ -146,7 +156,7 @@ export default function MainGraph(props) {
             y: yAxis,
             type: 'scatter',
             mode: 'markers',
-            marker: { color: 'red' },
+            marker: { color: color },
           },
         ]}
         layout={{

--- a/src/frontend/components/utils/TestsSummary.jsx
+++ b/src/frontend/components/utils/TestsSummary.jsx
@@ -125,7 +125,6 @@ export default function TestsSummary(props) {
     } else {
       setColor('orange');
     }
-    console.log(color);
   }, [runs, summary]);
 
   if (!isLoaded) {

--- a/src/frontend/components/utils/TestsSummary.jsx
+++ b/src/frontend/components/utils/TestsSummary.jsx
@@ -116,11 +116,16 @@ export default function TestsSummary(props) {
       setIsLoaded(true);
     }
 
-    if (summary == 'speedtest-cli-single-stream') {
-      setColor('orange');
-    } else {
+    if (
+      summary.toLowerCase() == 'ndt' ||
+      summary.toLowerCase() == 'ndt5' ||
+      summary.toLowerCase() == 'ndt7'
+    ) {
       setColor('red');
+    } else {
+      setColor('orange');
     }
+    console.log(color);
   }, [runs, summary]);
 
   if (!isLoaded) {

--- a/src/frontend/components/utils/TestsSummary.jsx
+++ b/src/frontend/components/utils/TestsSummary.jsx
@@ -102,8 +102,8 @@ function handleData(runs) {
 
 export default function TestsSummary(props) {
   const classes = useStyles();
-  const [testSummary, setTestSummary] = React.useState(null);
   const [isLoaded, setIsLoaded] = React.useState(false);
+  const [color, setColor] = React.useState('red');
   const { runs, summary } = props;
 
   React.useEffect(() => {
@@ -112,9 +112,14 @@ export default function TestsSummary(props) {
         return run.TestName === summary;
       });
 
-      setTestSummary(filteredRuns);
       handleData(filteredRuns);
       setIsLoaded(true);
+    }
+
+    if (summary == 'speedtest-cli-single-stream') {
+      setColor('orange');
+    } else {
+      setColor('red');
     }
   }, [runs, summary]);
 
@@ -152,7 +157,7 @@ export default function TestsSummary(props) {
                 y: yAxisWeek,
                 type: 'scatter',
                 mode: 'lines+markers',
-                marker: { color: 'rgb(52, 235, 107)' },
+                marker: { color: color },
                 hoverinfo: 'none',
               },
             ]}
@@ -207,7 +212,7 @@ export default function TestsSummary(props) {
                 y: yAxisDay,
                 type: 'scatter',
                 mode: 'lines+markers',
-                marker: { color: 'rgb(235, 64, 52)' },
+                marker: { color: color },
                 hoverinfo: 'none',
               },
             ]}


### PR DESCRIPTION
This PR:

- Fixes #92 (different test type colors)
- Fixes #108 (different test colors for 24 hrs/7 days)
- Fixes #109 (updates hover text)
- Updates #111 (temporarily disable By Day grouping button)